### PR TITLE
pinet patch 1.0.1 -> 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3904,9 +3904,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
-      "integrity": "sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
       "dev": true
     },
     "hosted-git-info": {
@@ -6364,13 +6364,13 @@
       "dev": true
     },
     "pinet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pinet/-/pinet-1.0.1.tgz",
-      "integrity": "sha512-+PEjFbgyHESGqDbB7W4HSK4D5MAO9kuSxuaselBFQwXJ4mnew2/QFdcRTbNwJ/n3Fp/TJs38QJoTI4MWocJUBQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pinet/-/pinet-1.0.2.tgz",
+      "integrity": "sha512-50flfHRxAnVQNC1FRtGCpgEH+Fb5b9gO3h2y/4Qgx12mK2a2+5yrcnaooWc1LZuwT/2kyxqbmXsYe5ymDQgURQ==",
       "dev": true,
       "requires": {
         "fs-extra": "9.0.1",
-        "highlight.js": "10.4.0",
+        "highlight.js": "10.4.1",
         "kyanite": "1.4.2",
         "marked": "1.2.5"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jsdoc": "3.6.6",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
-    "pinet": "1.0.1",
+    "pinet": "1.0.2",
     "rollup": "2.33.2",
     "rollup-plugin-cleanup": "3.2.1",
     "rollup-plugin-filesize": "9.0.2",


### PR DESCRIPTION
Patched pinet from 1.0.1 -> 1.0.2 in order to address highlight.js issue, this has no affect on the actual library or production build so no release is needed.